### PR TITLE
fix: relax the timeout

### DIFF
--- a/container/go/pkg/panosapi/panosapi.go
+++ b/container/go/pkg/panosapi/panosapi.go
@@ -26,7 +26,7 @@ func httpClient() *http.Client {
 			MaxIdleConnsPerHost: 2,
 			IdleConnTimeout:     90 * time.Second, // Palo Alto has a keepalive of 90 seconds server side, so lets do this also client side
 		},
-		Timeout: 5 * time.Second,
+		Timeout: 10 * time.Second,
 	}
 
 	return client


### PR DESCRIPTION
This is edged sword: It helps lowly spec'd palo alto during a content update. But it slows down the responsiveness of this component.

In order to fix this completly this component needs a Buffer per device.